### PR TITLE
fix: Admin users enabled with passwordless sudo via cloud-init

### DIFF
--- a/roles/proxmox/pve-node/tasks/user-permissions.yml
+++ b/roles/proxmox/pve-node/tasks/user-permissions.yml
@@ -1,4 +1,5 @@
 - name: Assign scoped roles to users
+  no_log: true
   ansible.builtin.lineinfile:
     path: /etc/pve/user.cfg
     create: false

--- a/roles/proxmox/virtual-machines/tasks/vm.yml
+++ b/roles/proxmox/virtual-machines/tasks/vm.yml
@@ -17,6 +17,7 @@
         - default
       {% for user in users_admin_users %}
         - name: {{ user.username }}
+          sudo: ALL=(ALL) NOPASSWD:ALL
           ssh_authorized_keys:
       {% for key in user.public_keys %}
           - {{ key }}


### PR DESCRIPTION
All users must be in sudoers so that they all can run environment set up in a single playbook run